### PR TITLE
Enable world record replays to be viewed and downloaded in-game

### DIFF
--- a/server/ts/index.ts
+++ b/server/ts/index.ts
@@ -10,7 +10,7 @@ import finalhandler from 'finalhandler';
 const serveStatic = serveStatic_;
 
 import { shared } from './shared';
-import { getDirectoryStructure, getVersionHistory, logUserError, registerActivity } from './misc';
+import { getDirectoryStructure, getVersionHistory, logUserError, registerActivity, getWorldRecordReplays } from './misc';
 import { getLeaderboard, submitScores, getWorldRecordSheet } from './leaderboard';
 import { getCustomLevelResource } from './customs';
 
@@ -89,6 +89,7 @@ const initServer = (port: number) => {
 						case 'error': await logUserError(res, body); break;
 						case 'version_history': await getVersionHistory(res); break;
 						case 'activity': await registerActivity(res, urlObject); break;
+						case 'world_record_replays': await getWorldRecordReplays(res, body); break;
 						default: break outer; // Incorrect API function
 					}
 

--- a/src/ts/ui/level_select_mbg.ts
+++ b/src/ts/ui/level_select_mbg.ts
@@ -119,7 +119,7 @@ export class MbgLevelSelect extends LevelSelect {
 		this.levelNumberElement.textContent = `Level ${this.currentMissionIndex + 1}`;
 	}
 
-	createScoreElement(includeReplayButton: boolean) {
+	createScoreElement(includeReplayButton: boolean, includeWorldRecordReplayButton: boolean) {
 		let element = document.createElement('div');
 		element.classList.add('level-select-best-time');
 
@@ -135,6 +135,9 @@ export class MbgLevelSelect extends LevelSelect {
 
 		if (includeReplayButton) {
 			element.appendChild(this.createReplayButton());
+		}
+		if (includeWorldRecordReplayButton) {
+			element.appendChild(this.createWorldRecordReplayButton());
 		}
 
 		return element;

--- a/src/ts/ui/level_select_mbp.ts
+++ b/src/ts/ui/level_select_mbp.ts
@@ -207,7 +207,7 @@ export class MbpLevelSelect extends LevelSelect {
 		this.easterEggIcon.classList.add('hidden');
 	}
 
-	createScoreElement(includeReplayButton: boolean) {
+	createScoreElement(includeReplayButton: boolean, includeWorldRecordReplayButton: boolean) {
 		let element = document.createElement('div');
 		element.classList.add('mbp-level-select-best-time');
 
@@ -219,6 +219,9 @@ export class MbpLevelSelect extends LevelSelect {
 
 		if (includeReplayButton) {
 			element.appendChild(this.createReplayButton());
+		}
+		if (includeWorldRecordReplayButton) {
+			element.appendChild(this.createWorldRecordReplayButton());
 		}
 
 		return element;


### PR DESCRIPTION
Hi Vani! This is something I've thought would be neat for a while, and I figured I'd take a stab at navigating the mbweb codebase and implementing it. If it's not something you want in the game, feel free to decline this PR and I won't be offended :) Also, I'm not really much of a web developer so I had to stumble around a few things as you can probably tell from the code.

This pull request enables world record wrecs to be played/downloaded/rendered in game by exposing an api endpoint which sends encoded wrec files to the client. See this quick demo:

https://youtu.be/ip3ZoYI07kk

Since PQ has this functionality, I've gotten used to being able to check out top scores and I thought it'd be fitting for mbweb to support it as well.

Some design considerations:

* I figured the most intuitive way for this to be implemented is to just show the replay button next to the top slot on the online leaderboards. Clicking, alt-clicking and ctrl-clicking all work just like normal replays do.

Some implementation considerations:

* I mostly hacked this into working :) On the server side, I added a new api endpoint that takes a list of missions and returns base64 encoded replay data for those missions. It'd probably be nice to gzip them, but I really don't know jack about how to do that and just wanted it to work for now lol
* I _think_ that this shouldn't allow the arbitrary reading of files from the filesystem since the replacement removes all forward and back slashes, but I'm not confident on that and we should make sure this is hardened against malicious mission paths.
* I'm not a frontend developer and so I really fumbled around the ui code lol - I created a new function largely based on the function which creates replay buttons to create the WR replay button and do some weird jank to get it to always appear in the first slot of the leaderboard. Right now it doesn't care if that wrec exists on the server or not, which is something it definitely should care about.
* There is also no rate limiting, so someone could try and scrape all of the wrecs putting a load on the server. I didn't do any testing but I'm assuming that would be substantial enough to cause issues.

Anyways, this was a fun project I whipped together in the last few hours. I feel like the mbweb community would enjoy this feature given how active it is and how often new records are set, and regardless of if you want to merge this, thanks for all your hard work on Marble Blast Web!